### PR TITLE
update element 4 of  article diff-way-of-wrinting-function

### DIFF
--- a/blog/js/different-way-of-writing-function.mdx
+++ b/blog/js/different-way-of-writing-function.mdx
@@ -51,10 +51,9 @@ const add = (a, b) => {
 Arrow short callbacks are a concise way of writing arrow functions that take only one argument and have a single expression as the function body.
 
 ```js:app.js
-const add = (a, b) => return a + b;
+const add = (a, b) =>  a + b;
 ```
-
-<Notes>You are not able to use more than two arguments.</Notes>
+It is particularly useful for simple and short functions, and it is not necessary to use the 'return' keyword to return a value when using this syntax.
 
 <Author
   name="Ali Reza"


### PR DESCRIPTION
## Short Description
Hi . 
 I have corrected the article on functions, when you do the arrow function on a line, you don't need to put the keyword 'return'. You can see here on MDN page . [Here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
`const add = (a, b) => a + b;` Thanks ;-)